### PR TITLE
Updated README to further clarify W3 messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ If you want to know how we reengineered it, read on here.
    an external program.
    </details>
 
-4. Proof of Concept  
+3. Proof of Concept  
 Try to inform the game server by sending an unicast instead of broadcast by an external tool. For this PoC we used the software [nping](https://nmap.org/nping/)  
    * Start on the remote computer (server) Warcraft 3.
    * Call nping (C:\Program Files (x86)\Nmap\nping) from command line on the client:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The problem with e.g. Warctaft 3 is that the server could not be found even if w
 > (VPN means here classic OSI layer 3 VPNs and not a OSI layer 2 bridge VPN.) 
 
 ## What is the reason for that?
-The game server sends an udp broadcast to notify all player in the LAN. When you play over internet via VPN there is normaly a consumer router which do not relay this braodcast otherwise the network/internet would be flooded.
+The game server sends an udp broadcast to notify all player in the LAN. When you play over internet via VPN there is normaly a consumer router which does not relay this broadcast otherwise the network/internet would be flooded.
 > (Only professional routers could do this with a directed broadcast)
 
 ## How we solved the problem
@@ -41,51 +41,66 @@ If you want to know how we reengineered it, read on here.
 2. Understand the Warcraft 3 communication on UDP port 6112
    * Install and start [Wireshark](https://www.wireshark.org/)
    * Set the Wireshark displayfilter to: ***udp.port == 6112***
-   * You can divide it in 3 Parts:
+   * You can divide it in 5 Parts:
 
      1. **"Hello" information"**  
-     When you enter the network lobby, Warcraft will only send a notifcation boradcast ***once***:
+     When you enter the network lobby, Warcraft will only send a notifcation broadcast ***once***:
         * Source: _local IP of client_
         * Destination: _255.255.255.255_
         * Port: _UDP 6112_
         * Data: _0xf72f1000505833571b00000000000000_
         >(the data is always the same for each warcraft pc)
+  
+     2. **"Server created"**
+     When you open a LAN game, the server sends a request similar to the "Hello" message **once**:
+        * Source: _local IP of the host_
+        * Destination: _255.255.255.255_
+        * Port: _UDP 6112_
+        * Data: _f7311000505833571b00000001000000_
+        >only the last 4 bytes change, which is the number of opened LAN games since Warcraft started for that client,
+        >most likely working as a local id.
  
-     2. **"Server waiting"**  
-     When you open a LAN game, the server sends every 5 seconds (may depend on the patch version) a notifcation boradcast:
+     4. **"Server waiting"**  
+     After you open a LAN game, the server sends every 5 seconds (may depend on the patch version) a notifcation boradcast:
         * Source: _local IP of server_
         * Destination: _255.255.255.255_
         * Port: _UDP 6112_ 
         * Data: _0xf7321000010000000100000003000000_  
         The data is defined as: 
         
-          \# (byte) | Data | dynamic  |  Description
-          --------- | ---- | -------- | -------------
-          01        |  f7  | no       | W3 identification (fix)
-          02        |  32  | no       | W3 identification (fix)
-          03        |  10  | no       | W3 identification (fix)
-          04        |  00  | no       | Reserved
-          05        |  01  | yes      | Number of opened LAN games since Warcraft started. (here 1)
-          06        |  00  | no       | Reserved
-          07        |  00  | no       | Reserved
-          08        |  00  | no       | Reserved
-          09        |  01  | no       | Total number of (joined) players in the game. (here only the server himself)
-          10        |  00  | no       | Reserved
-          11        |  00  | no       | Reserved
-          12        |  00  | no       | Reserved
-          13        |  03  | no       | Number of possible players on the map. (here 3)
-          14        |  00  | no       | Reserved
-          15        |  00  | no       | Reserved
-          16        |  00  | no       | Reserved
+          \# (byte) | Data   | dynamic  |  Description
+          --------- | ------ | -------- | -------------
+          01        |  f7    | no       | W3 identification (fixed)
+          02        |  32    | no       | W3 op-code (0x32 = server waiting)
+          03-04     |  10    | no       | Total length of the payload, unsigned short in little endian order (here 16 bytes including this header)
+          05-08     |  01    | yes      | Number of opened LAN games since Warcraft started, unsigned int in little endian order. (here 1)
+          09-12     |  01    | no       | Total number of (joined) players in the game, unsigned int in little endian order. (here only the server himself)
+          13-16     |  03    | no       | Number of possible players on the map, unsigned int in little endian order. (here 3)
         
-     3. **"Abort"**  
+     5. **"Abort"**  
      When you abort the open game:
         * Source: _local IP of client_
         * Destination: _255.255.255.255_
         * Port: _UDP 6112_
         * Data: _0xf733080001000000_
+        >the number of created LAN games/id is also sent at the last 4 bytes
 
-3. Proof of Concept  
+   <details>
+   All the messages have the format:
+     
+   * Starting byte _0xf7_ as a magic number to identify W3 messages
+   * Op-code going from _0x2f_ to _0x33_ indicating what is the content of the message
+   * 16-bit unsigned int in little endian order to indicate the total length of the message (this header included)
+   * The payload which has a byte-length given by the length value minus the header length (4 bytes)
+  
+   ---
+    
+   There is also a sixth type of UDP message starting with _0xf730..._ which sends the entire lobby information which includes the name of the host
+   and it's sent to any peers sending the "Hello" message. Not included in this readme, but you can use this information if you want to display it in
+   an external program.
+   </details>
+
+4. Proof of Concept  
 Try to inform the game server by sending an unicast instead of broadcast by an external tool. For this PoC we used the software [nping](https://nmap.org/nping/)  
    * Start on the remote computer (server) Warcraft 3.
    * Call nping (C:\Program Files (x86)\Nmap\nping) from command line on the client:


### PR DESCRIPTION
* Added more detail to the Warcraft III message payloads
* Op-code clarification
* Clarification about header lengths
* Clarification about int and short numbers in little endian
* Added _\<detail>_ section for more information

I know this goes kinda out of scope for this project, but this info really helped me in another project. I updated this README with new discoveries I made in the hope that this further helps in other projects related to Warcraft III.